### PR TITLE
catch more soundtracks

### DIFF
--- a/naming_scripts/Bob_Swift/Bob Swift's Naming Script.pts
+++ b/naming_scripts/Bob_Swift/Bob Swift's Naming Script.pts
@@ -346,7 +346,7 @@ $noop(
 -  'soundtrack'.  Also add the track artist to the track title.        -
 ------------------------------------------------------------------------
 )
-$if($in(%_secondaryreleasetype%,soundtrack),
+$if($in(releasetype%,soundtrack),
     $set(_nAlbumType,Soundtrack)
     $set(_nFeat, [%_nFTA%])
 )

--- a/naming_scripts/Bob_Swift/Bob Swift's Naming Script.pts
+++ b/naming_scripts/Bob_Swift/Bob Swift's Naming Script.pts
@@ -346,7 +346,7 @@ $noop(
 -  'soundtrack'.  Also add the track artist to the track title.        -
 ------------------------------------------------------------------------
 )
-$if($in(releasetype%,soundtrack),
+$if($in(%releasetype%,soundtrack),
     $set(_nAlbumType,Soundtrack)
     $set(_nFeat, [%_nFTA%])
 )


### PR DESCRIPTION
i have a consistent issue with this script where if the album is not in the musicbrainz database, it treats it as a standard release. i believe it's due to this check on the hidden `_secondaryreleasetype` variable, which is something probably added by picard on a match based on db metadata. since it seems semi-MB specific, albums i acquire (eg off Steam or Bandcamp) that are soundtracks and don't have database entries yet aren't properly sorted.

i add `album,soundtrack` values to the `releasetype` tag for any soundtracks i add myself that don't already have them, but the script doesn't catch that. 

my question is, is there any reason it needs to only check for the hidden tag? perhaps the logic should actually check if `soundtrack` is in _either_ tag, open to that as well